### PR TITLE
Miscellaneous fixes to attachment handling

### DIFF
--- a/zotrm/zotrm.py
+++ b/zotrm/zotrm.py
@@ -90,7 +90,9 @@ def main(verbose=False):
         while queue:
             item = queue.pop()
             if item['data']['itemType'] != 'attachment':
-                queue += zot.children(item['key'])
+                # Note items don't have children to look through
+                if item['data']['itemType'] != 'note':
+                    queue += zot.children(item['key'])
                 continue
             # Get filename
             if 'filename' in item['data']:

--- a/zotrm/zotrm.py
+++ b/zotrm/zotrm.py
@@ -130,6 +130,11 @@ def main(verbose=False):
                         if os.path.exists(f):
                             attachments.append(f)
 
+        # If no attachments were found, skip the upload
+        if not attachments:
+            print("\tNo attachments found, skipping upload")
+            continue
+
         if verbose:
             for f in attachments:
                 print("\tFound PDF attachment {:s}".format(os.path.basename(f)))

--- a/zotrm/zotrm.py
+++ b/zotrm/zotrm.py
@@ -116,12 +116,14 @@ def main(verbose=False):
                     attachments.append(filename)
             else:
                 # Without linked attachments, PDF is in some subdirectory.
-                filename = os.path.join(config['zot_storage_dir'], '[A-Z0-9]*/' + filename)
-                r = re.compile(filename)
+                dirname = re.escape(config['zot_storage_dir'])
+                regexfilename = re.escape(filename)
+                regexfilename = os.path.join(dirname, '[A-Z0-9]*/' + regexfilename)
+                r = re.compile(regexfilename)
                 # Match files to list
                 foundfiles = list(filter(r.match, pdflist))
                 if len(foundfiles) < 1 :
-                    print("ERR: Cannot find file {:s}, skipping...".format(flename))
+                    print("ERR: Cannot find file \"{:s}\" in storage directory \"{:s}\", skipping...".format(filename,dirname))
                     continue
                 else:
                     for f in foundfiles:


### PR DESCRIPTION
This PR changes two parts:

1. It escapes the file and directory names before they are given to the regex so that the parts of the names are never interpreted as being regex commands (otherwise filenames with () in it would not be found).
2. Don't continue upload process if no attachments were found - since there is no point in continuing if there is nothing to upload.